### PR TITLE
fix: 절대경로(NODE_PATH) 동작 안되는 버그

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-NODE_PATH=src

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  }
+}


### PR DESCRIPTION
## 해결
- [참고 링크](https://kingso.netlify.app/posts/20190916-TIL/)
- webpack에게 src를 알려주는 방식을 사용하자.